### PR TITLE
Update pom.xml for security and plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,14 @@
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <version>1.9.4</version>
+      <exclusions>
+        <!-- Exclude commons-collections due to CVE issue -->
+        <!-- https://devhub.checkmarx.com/cve-details/Cx78f40514-81ff/ -->
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -140,8 +148,9 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-plugin</artifactId>
-        <version>1.11.1</version>
+        <version>2.0.1</version>
         <configuration>
           <tag>v${project.version}</tag>
         </configuration>


### PR DESCRIPTION
In this commit, the commons-collections library is excluded from the commons-beanutils dependency due to a CVE security issue. Also, the maven-scm-plugin version has been upgraded to 2.0.1.